### PR TITLE
Daily hours widget broken

### DIFF
--- a/classes/widgets/DailyHours.php
+++ b/classes/widgets/DailyHours.php
@@ -26,10 +26,57 @@ class DailyHours extends \WP_Widget {
 
 	function widget( $args, $instance ) {
 		if($details = get_transient( 'psrm-details' )) {
+            $hours = $details->opening_hours;
+            $open_hours = '';
+
+            if ($hours->open_now) {
+                $open_hours = 'currently <p class="museum-status museum-open" > OPEN</p> until ';
+
+                $today = date('w');
+                foreach ($hours->periods as $day) {
+                    if ($today == $day->open->day) {
+                        $open_hours .= date('g:i a', strtotime($day->close->time));
+                    }
+                }
+            } else {
+                $day_of_week = date('w');
+                $current_hour = date('Hi');
+
+                $found_on_first_check = false;
+
+                foreach ($hours->periods as $day) {
+                    if ($day_of_week == $day->open->day && $current_hour <= $day->close->time) {
+                        $open_hours = '<p class="museum-status museum-open">OPEN TODAY</p> from ' . date('g:i a', strtotime($day->open->time)) . ' - ' . date('g:i a', strtotime($day->close->time));
+                        $found_on_first_check = true;
+                        break;
+                    } else {
+                        if ($day_of_week == 6 && $current_hour > $day->close->time) {
+                            $today = -1;
+                        } else {
+                            $today = $day_of_week;
+                        }
+
+                        if ($current_hour > $day->close->time) {
+                            $today++;
+                        }
+
+                        if ($today <= $day->open->day) {
+                            $open_hours = 'currently <p class="museum-status museum-closed">CLOSED</p> until ' . \psrm\controllers\GooglePlaces::$dowMap[$day->open->day] . ': ' . date('g:i a', strtotime($day->open->time)) . ' - ' . date('g:i a', strtotime($day->close->time));
+                            $found_on_first_check = true;
+                            break;
+                        }
+                    }
+                }
+
+                if (!$found_on_first_check) {
+                    $day = $hours->periods[0];
+                    $open_hours = 'currently <p class="museum-status museum-closed">CLOSED</p> until ' . \psrm\controllers\GooglePlaces::$dowMap[$day->open->day] . ': ' . date('g:i a', strtotime($day->open->time)) . ' - ' . date('g:i a', strtotime($day->close->time));
+                }
+            }
 			echo $this->view->render( 'daily-hours', [
 				'args'     => $args,
 				'instance' => $instance,
-				'details'  => $details
+				'open_hours'  => $open_hours
 			] );
 		}
 	}

--- a/resources/views/daily-hours.phtml
+++ b/resources/views/daily-hours.phtml
@@ -1,43 +1,5 @@
-<?php
-$hours = $details->opening_hours;
-echo $args[ 'before_widget' ]
-?>
-	<div class="daily-hours">
-		The museum is
-		<?php if ( $hours->open_now ): ?>
-			currently <p class="museum-status museum-open">OPEN</p> until
-			<?php
-			$today = date( 'w' );
-			foreach ( $hours->periods as $day ) {
-				if ( $today == $day->open->day ) {
-					echo date( 'g:i a', strtotime( $day->close->time ) );
-				}
-			}
-		else:
-			$day_of_week  = date( 'w' );
-			$current_hour = date( 'Hi' );
-			foreach ( $hours->periods as $day ) {
-				if ( $day_of_week == $day->open->day && $current_hour <= $day->close->time ) {
-					echo '<p class="museum-status museum-open">OPEN TODAY</p> from ' . date( 'g:i a', strtotime( $day->open->time ) ) . ' - ' . date( 'g:i a', strtotime( $day->close->time ) );
-					break;
-				} else {
-					if ( $day_of_week == 6 && $current_hour > $day->close->time ) {
-						$today = - 1;
-					} else {
-						$today = $day_of_week;
-					}
-
-					if ( $current_hour > $day->close->time ) {
-						$today ++;
-					}
-
-					if ( $today <= $day->open->day ) {
-						echo 'currently <p class="museum-status museum-closed">CLOSED</p> until ' . \psrm\controllers\GooglePlaces::$dowMap[ $day->open->day ] . ': ' . date( 'g:i a', strtotime( $day->open->time ) ) . ' - ' . date( 'g:i a', strtotime( $day->close->time ) );
-						break;
-					}
-				}
-			}
-			?>
-		<?php endif; ?>
-	</div>
-<?php echo $args[ 'after_widget' ]; ?>
+<?php echo $args['before_widget'] ?>
+    <div class="daily-hours">
+        The museum is <?= $open_hours ?>
+    </div>
+<?php echo $args['after_widget'] ?>


### PR DESCRIPTION
The daily hours widget was broken if the next open day is a prior day in the next week (e.g. open Sunday and today's Monday).
 
Fixes #31 